### PR TITLE
Change reply rectangle height and color for sticker messages

### DIFF
--- a/utils/quote-generate.js
+++ b/utils/quote-generate.js
@@ -858,7 +858,8 @@ class QuoteGenerate {
 
     let rect
     if (mediaType === 'sticker' && (name || replyName)) {
-      rectHeight -= mediaHeight + indent * 2
+      rectHeight = (replyName.height + replyText.height * 0.5) + indent * 2
+      backgroundColorOne = backgroundColorTwo = 'rgba(0, 0, 0, 0.5)'
     }
 
     if (mediaType !== 'sticker' || name || replyName) {


### PR DESCRIPTION
Fixed the calculation of the reply rectangle height for sticker messages and updated the color to black with 0.5 opacity.

Before: 
![Quotly-Before](https://github.com/user-attachments/assets/34cc60a3-18bb-4e38-9f61-b011ccf67410)
After: 
![Quotly-After](https://github.com/user-attachments/assets/d3a59708-b1ae-4dfe-b2e6-a1948ef6c3fc)
